### PR TITLE
Fixed bug in exception to response mapping.

### DIFF
--- a/guja-core/src/main/java/com/wadpam/guja/exceptions/RestExceptionMapper.java
+++ b/guja-core/src/main/java/com/wadpam/guja/exceptions/RestExceptionMapper.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Singleton;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
@@ -63,9 +64,14 @@ public class RestExceptionMapper implements ExceptionMapper<RestException> {
     errorMessage.put("responseCode", String.valueOf(exception.getStatus().getStatusCode()));
 
     return Response.status(exception.getStatus())
-        .entity(errorMessage.build())
-        .type(httpHeaders.getAcceptableMediaTypes().get(0))
-        .build();
+            .entity(errorMessage.build())
+            // Throws exception if type is MediaType.WILDCARD_TYPE
+            .type(getAcceptableMediaTypeNotWildcard())
+            .build();
   }
 
+  private MediaType getAcceptableMediaTypeNotWildcard() {
+    MediaType type = httpHeaders.getAcceptableMediaTypes().get(0);
+    return MediaType.WILDCARD_TYPE.equals(type) ? null : type;
+  }
 }


### PR DESCRIPTION
For some reason the `ResponseBuilder` throws an exception if the type is `MediaType.WILDCARD_TYPE`, which in turn will result in an internal server error. This is annoying since it happens if you forget to include the Accept header in the request.
