### PR TITLE
Conform to OAuth 2.0 by using token_type Bearer when authorizing.

### DIFF
--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/api/OAuth2Resource.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/api/OAuth2Resource.java
@@ -81,6 +81,7 @@ public class OAuth2Resource {
   private static final String PASSWORD_GRANT_TYPE = "password";
   private static final String REFRESH_TOKEN_GRANT_TYPE = "refresh_token";
   private static final int DEFAULT_EXPIRES_IN = 60 * 60 * 24 * 7;  // 1 week
+  private static final String TOKEN_TYPE_BEARER = "Bearer";
 
   private final DConnectionDaoBean connectionDao;
   private final DFactoryDaoBean factoryDao;
@@ -165,6 +166,7 @@ public class OAuth2Resource {
           .put("access_token", connection.getAccessToken())
           .put("refresh_token", connection.getRefreshToken())
           .put("expires_in", DEFAULT_EXPIRES_IN)
+          .put("token_type", TOKEN_TYPE_BEARER)
           .build())
           .cookie(createCookie(connection.getAccessToken(), DEFAULT_EXPIRES_IN))
           .build();

--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
@@ -56,7 +56,7 @@ public class OAuth2Filter implements Filter {
   public static final String NAME_CONNECTION = "oauth2connection";
   public static final String NAME_ROLES = "oauth2user.roles";
   public static final String HEADER_AUTHORIZATION = "Authorization";
-  public static final String PREFIX_OAUTH = "OAuth ";
+  public static final String PREFIX_BEARER = "Bearer ";
 
   static final Logger LOGGER = LoggerFactory.getLogger(OAuth2Filter.class);
 
@@ -127,9 +127,9 @@ public class OAuth2Filter implements Filter {
     if (null == accessToken && null != request.getHeader(HEADER_AUTHORIZATION)) {
       String auth = request.getHeader(HEADER_AUTHORIZATION);
       LOGGER.debug("{}: {}", HEADER_AUTHORIZATION, auth);
-      int beginIndex = auth.indexOf(PREFIX_OAUTH);
+      int beginIndex = auth.indexOf(PREFIX_BEARER);
       if (-1 < beginIndex) {
-        return auth.substring(beginIndex + PREFIX_OAUTH.length());
+        return auth.substring(beginIndex + PREFIX_BEARER.length());
       }
     }
 


### PR DESCRIPTION
This pull request is a suggestion that is __not__ backwards compatible. OAuth 2.0 specifies `token_type` as a required field when responding to a successful authorization ([see RFC 6749 section 5.1](http://tools.ietf.org/html/rfc6749#section-5.1)). I've added this field, set it to `Bearer` and changed the behavior to match that of the Bearer token type.

The Bearer token type is specified in [RFC 6750](http://tools.ietf.org/html/rfc6750). It is very similar to what was done before, with the exception that it uses `Bearer` as a prefix in the authorization header instead of `OAuth` (i.e. `Authorization: Bearer [the-token]` instead of `Authorization: OAuth [the-token]`). The alternatives (that still remain standard compliant), as I see it, would have been to 1) define a custom token type to represent the behavior or 2) use the bearer token type but still also check for the OAuth prefix.