### PR TITLE
Bugfix/protected resource request

### DIFF
--- a/guja-core/pom.xml
+++ b/guja-core/pom.xml
@@ -91,6 +91,10 @@
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
@@ -58,6 +58,7 @@ public class OAuth2Filter implements Filter {
   public static final String HEADER_AUTHORIZATION = "Authorization";
   public static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
   public static final String PREFIX_BEARER = "Bearer ";
+  public static final String ERROR_INVALID_TOKEN = "error=\"invalid_token\"";
 
   static final Logger LOGGER = LoggerFactory.getLogger(OAuth2Filter.class);
 
@@ -104,7 +105,7 @@ public class OAuth2Filter implements Filter {
         LOGGER.debug("Unauthorised");
         // TODO Should be return 401 or allow the user to continue as anonymous?
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setHeader(HEADER_WWW_AUTHENTICATE, PREFIX_BEARER);
+        response.setHeader(HEADER_WWW_AUTHENTICATE, PREFIX_BEARER + ERROR_INVALID_TOKEN);
         return;
       }
 

--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/web/OAuth2Filter.java
@@ -56,6 +56,7 @@ public class OAuth2Filter implements Filter {
   public static final String NAME_CONNECTION = "oauth2connection";
   public static final String NAME_ROLES = "oauth2user.roles";
   public static final String HEADER_AUTHORIZATION = "Authorization";
+  public static final String HEADER_WWW_AUTHENTICATE = "WWW-Authenticate";
   public static final String PREFIX_BEARER = "Bearer ";
 
   static final Logger LOGGER = LoggerFactory.getLogger(OAuth2Filter.class);
@@ -103,6 +104,7 @@ public class OAuth2Filter implements Filter {
         LOGGER.debug("Unauthorised");
         // TODO Should be return 401 or allow the user to continue as anonymous?
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader(HEADER_WWW_AUTHENTICATE, PREFIX_BEARER);
         return;
       }
 

--- a/guja-core/src/test/java/com/wadpam/guja/oauth2/web/OAuth2FilterTest.java
+++ b/guja-core/src/test/java/com/wadpam/guja/oauth2/web/OAuth2FilterTest.java
@@ -1,0 +1,72 @@
+package com.wadpam.guja.oauth2.web;
+
+import com.google.inject.Provider;
+import com.wadpam.guja.oauth2.dao.DConnectionDaoBean;
+import com.wadpam.guja.oauth2.dao.DOAuth2UserDaoBean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by sosandstrom on 2015-01-16.
+ */
+public class OAuth2FilterTest {
+
+    OAuth2Filter filter;
+    final ProviderReference<DConnectionDaoBean> connectionDaoProvider = new ProviderReference<>();
+    final ProviderReference<DOAuth2UserDaoBean> userDaoProvider = new ProviderReference<>();
+    DConnectionDaoBean connectionDaoMock;
+    DOAuth2UserDaoBean userDaoMock;
+    private FilterChain chainMock;
+    MockHttpServletRequest request;
+    MockHttpServletResponse response;
+
+    @Before
+    public void setUp() {
+        connectionDaoMock = createMock(DConnectionDaoBean.class);
+        connectionDaoProvider.set(connectionDaoMock);
+        userDaoMock = createMock(DOAuth2UserDaoBean.class);
+        userDaoProvider.set(userDaoMock);
+        filter = new OAuth2Filter(connectionDaoProvider, userDaoProvider);
+        chainMock = createMock(FilterChain.class);
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    public void testExpiredToken() throws IOException, ServletException {
+        request.setParameter("access_token", "abc123");
+        expect(connectionDaoMock.findByAccessToken("abc123")).andReturn(null).once();
+        replayAll();
+
+        filter.doFilter(request, response, chainMock);
+
+        assertEquals(401, response.getStatus());
+        assertEquals("Bearer ", response.getHeader("WWW-Authenticate"));
+    }
+
+    private void replayAll() {
+        replay(connectionDaoMock, userDaoMock, chainMock);
+    }
+
+    @After
+    public void tearDown() {
+        verify(connectionDaoMock, userDaoMock, chainMock);
+    }
+
+    static class ProviderReference<T> extends AtomicReference<T> implements Provider<T> {
+
+    }
+}

--- a/guja-core/src/test/java/com/wadpam/guja/oauth2/web/OAuth2FilterTest.java
+++ b/guja-core/src/test/java/com/wadpam/guja/oauth2/web/OAuth2FilterTest.java
@@ -54,7 +54,7 @@ public class OAuth2FilterTest {
         filter.doFilter(request, response, chainMock);
 
         assertEquals(401, response.getStatus());
-        assertEquals("Bearer ", response.getHeader("WWW-Authenticate"));
+        assertEquals("Bearer error=\"invalid_token\"", response.getHeader("WWW-Authenticate"));
     }
 
     private void replayAll() {

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
                 <version>3.1</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-test</artifactId>
+                <version>3.2.0.RELEASE</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Fixes issue #14 

3.  The WWW-Authenticate Response Header Field

   If the protected resource request does not include authentication
   credentials or does not contain an access token that enables access
   to the protected resource, the resource server MUST include the HTTP
   "WWW-Authenticate" response header field; it MAY include it in
   response to other conditions as well.  The "WWW-Authenticate" header
   field uses the framework defined by HTTP/1.1 [RFC2617].

   All challenges defined by this specification MUST use the auth-scheme
   value "Bearer".  This scheme MUST be followed by one or more
   auth-param values.  The auth-param attributes used or defined by this
   specification are as follows.  Other auth-param attributes MAY be
   used as well.

3.1.  Error Codes

   When a request fails, the resource server responds using the
   appropriate HTTP status code (typically, 400, 401, 403, or 405) and
   includes one of the following error codes in the response:

   invalid_token
         The access token provided is expired, revoked, malformed, or
         invalid for other reasons.  The resource SHOULD respond with
         the HTTP 401 (Unauthorized) status code.  The client MAY
         request a new access token and retry the protected resource
         request.
