### PR TITLE
Allow unicode characters in passwords

### DIFF
--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/api/UserResource.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/api/UserResource.java
@@ -58,7 +58,7 @@ public class UserResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserResource.class);
 
   private static final Pattern USERNAME_PATTERN = Pattern.compile("^.{5,}$");
-  private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]{5,}$");
+  private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[^\\x00-\\x1F]{5,}$");
   private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$");
 
   private UserService userService;

--- a/guja-core/src/main/java/com/wadpam/guja/oauth2/api/UserResource.java
+++ b/guja-core/src/main/java/com/wadpam/guja/oauth2/api/UserResource.java
@@ -58,7 +58,7 @@ public class UserResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserResource.class);
 
   private static final Pattern USERNAME_PATTERN = Pattern.compile("^.{5,}$");
-  private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[^\\x00-\\x1F]{5,}$");
+  private static final Pattern PASSWORD_PATTERN = Pattern.compile("^[\\x21-\\x7E\\xA0-\\xBF\\w]{5,}$", Pattern.UNICODE_CHARACTER_CLASS);
   private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$");
 
   private UserService userService;


### PR DESCRIPTION
I suggest allowing all unicode characters except some non printable ones (0x00 - 0x1F) in passwords.
