### PR TITLE
Added support for equal signs in the version expression.

### DIFF
--- a/guja-base/src/main/java/com/wadpam/guja/api/SemanticVersionCheckPredicate.java
+++ b/guja-base/src/main/java/com/wadpam/guja/api/SemanticVersionCheckPredicate.java
@@ -57,7 +57,7 @@ public class SemanticVersionCheckPredicate implements VersionCheckResource.Versi
   }
 
   private static Map<String, String> parsePropertyMap(String formattedMap) {
-    return Splitter.on(",").withKeyValueSeparator("=").split(formattedMap);
+    return Splitter.on(",").withKeyValueSeparator(":").split(formattedMap);
   }
 
   @Override

--- a/guja-base/src/test/java/com/wadpam/guja/SemanticVersionCheckPredicateTest.java
+++ b/guja-base/src/test/java/com/wadpam/guja/SemanticVersionCheckPredicateTest.java
@@ -38,10 +38,7 @@ public class SemanticVersionCheckPredicateTest {
   @Before
   public void setUp() throws Exception {
 
-    predicate = new SemanticVersionCheckPredicate(ImmutableMap.<String, String>builder()
-        .put("ios", "1.0.0")
-        .put("android", ">=1.5")
-        .build());
+    predicate = new SemanticVersionCheckPredicate("ios:1.0.0,android:>=1.5");
 
   }
 


### PR DESCRIPTION
This commit changes the key value separator to `:` (previously it was `=`). The reason for this is to allow version expressions like `>=1.5` (before this commit that equal sign would have been interpreted as a key-value separator).